### PR TITLE
Don´t force the driver-type in metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ readme = "Readme.md"
 keywords = ["windows", "driver", "mutex", "kernel", "wdk"]
 description = "An idiomatic Rust mutex type for Windows kernel driver development."
 
-[package.metadata.wdk.driver-model]
-driver-type = "WDM"
-
 [lib]
 crate-type = ["lib"]
 


### PR DESCRIPTION
If you depend on `wdk-mutex` but your driver type is not `WDM`, the build fails (`cargo make default`), because there will be two configurations for `wdk`.  Removing the driver-type from `wdk-mutex`metadata solves the build issue. 